### PR TITLE
lock prometheus-client as 0.9.x so as to keep compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     grpc_prometheus (0.1.0)
       grpc (~> 1.7)
-      prometheus-client
+      prometheus-client (~> 0.9.0)
 
 GEM
   remote: https://rubygems.org/

--- a/grpc_prometheus.gemspec
+++ b/grpc_prometheus.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "grpc", "~> 1.7"
-  spec.add_dependency "prometheus-client"
+  spec.add_dependency "prometheus-client", "~> 0.9.0"
 
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
The latest version (v0.10.0) of prometheus-client includes [a breaking change](https://github.com/prometheus/client_ruby/pull/95).

```diff
- def counter(name, docstring, base_labels = {})
+ def counter(name, docstring:, labels: [], preset_labels: {}, store_settings: {})
```

```
1: from /vendor/bundle/2.5.3/gems/grpc_prometheus-0.1.0/lib/grpc_prometheus/server_metrics.rb:12:in `initialize'
/vendor/bundle/2.5.3/gems/prometheus-client-0.10.0/lib/prometheus/client/registry.rb:40:in `counter': wrong number of arguments (given 2, expected 1; required keyword: docstring) (ArgumentError)
```

However, v0.10.0 is yet to be officially released yet.
So, In order to avoid exceptions there, could it be possible for this gem to fix the dependency's version until gaining the compatibility?
